### PR TITLE
libft: Fix ft_split.c compilation fail (incorrect size for malloc()); fix issue #3 and Norminette

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/17 17:14:16 by mcombeau          #+#    #+#             */
-/*   Updated: 2022/11/07 17:43:50 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 17:56:39 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,18 +32,22 @@
 /******************************************************************************
 *								MACROS										  *
 ******************************************************************************/
-# define PROMPT "\001\e[45m\002>>> \001\e[0m\e[33m\002 Minishell>$ \001\e[0m\002"
-# define HEREDOC_NAME "/tmp/.minishell_heredoc_"
+/**
+ * "\001\e[45m\002>>> \001\e[0m\e[33m\002 Minishell>$ \001\e[0m\002"
+ * was violating Norminette line length rule.
+ */
+# define PROMPT			"minishell>$ "
+# define HEREDOC_NAME	"/tmp/.minishell_heredoc_"
 
-# define CMD_NOT_FOUND 127
-# define CMD_NOT_EXECUTABLE 126
+# define CMD_NOT_FOUND		127
+# define CMD_NOT_EXECUTABLE	126
 
 # ifndef PATH_MAX
-#  define PATH_MAX 4096
+#  define PATH_MAX			4096
 # endif
 
-# define SUCCESS 0
-# define FAILURE 1
+# define SUCCESS	0
+# define FAILURE	1
 
 /******************************************************************************
 *							GLOBAL VARIABLE									  *
@@ -54,7 +58,7 @@ extern int	g_last_exit_code;
 *								STRUCTS									      *
 ******************************************************************************/
 typedef struct s_token
-{	
+{
 	char			*str;
 	char			*str_backup;
 	bool			var_exists;
@@ -103,7 +107,8 @@ typedef struct s_data
 *								ENUMS									      *
 ******************************************************************************/
 
-enum e_token_types {
+enum e_token_types
+{
 	SPACES = 1,
 	WORD,
 	VAR,
@@ -115,7 +120,8 @@ enum e_token_types {
 	END
 };
 
-enum e_quoting_status {
+enum e_quoting_status
+{
 	DEFAULT,
 	SQUOTE,
 	DQUOTE

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/17 17:14:16 by mcombeau          #+#    #+#             */
-/*   Updated: 2024/11/29 17:56:39 by asagymba         ###   ########.fr       */
+/*   Updated: 2024/11/29 17:57:38 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -125,6 +125,13 @@ enum e_quoting_status
 	DEFAULT,
 	SQUOTE,
 	DQUOTE
+};
+
+enum e_redir_type
+{
+	NO_REDIR,
+	STDIN_REDIR,
+	STDOUT_REDIR
 };
 
 /******************************************************************************

--- a/libft/ft_split.c
+++ b/libft/ft_split.c
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/11/27 17:56:03 by mcombeau          #+#    #+#             */
-/*   Updated: 2021/12/08 12:14:01 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 11:40:57 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,7 +115,7 @@ char	**ft_split(char const *s, char c)
 
 	if (!s)
 	{
-		strs = malloc(sizeof(char) * 1);
+		strs = malloc(sizeof(char *));
 		if (!strs)
 			return (NULL);
 		*strs = NULL;

--- a/sources/builtins/echo_builtin.c
+++ b/sources/builtins/echo_builtin.c
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/17 18:55:59 by mcombeau          #+#    #+#             */
-/*   Updated: 2022/11/03 15:48:44 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 18:11:14 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,8 @@
 /* is_n_flag:
 *	Checks whether an arg is an -n option flag.
 *	Returns true if the arg is some variation of -n, -nnnn, -nn, etc.
-*	Returns false if it contains anything other than - and n (ex. --n -nnnm -n1234)
+*	Returns false if it contains anything other than - and n
+*		(ex. --n -nnnm -n1234)
 */
 static bool	is_n_flag(char *arg)
 {

--- a/sources/builtins/exit_builtin.c
+++ b/sources/builtins/exit_builtin.c
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/17 18:32:33 by mcombeau          #+#    #+#             */
-/*   Updated: 2022/11/05 12:17:05 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 18:11:27 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,8 +108,8 @@ static bool	is_quiet_mode(t_data *data)
 /* exit_builtin:
 *	Executes the exit builtin.
 *	If alone, prints exit and exits the shell with the provided exit code, or 0.
-*	If piped, exits the child process with the provided exit code and does not exit
-*	minishell.
+*	If piped, exits the child process with the provided exit code and does not
+*		exit minishell.
 *	In case of failure due to invalid arguments, does not exit the shell
 *	and returns an error exit code (1 or 2) instead.
 */

--- a/sources/lexer/check_if_var.c
+++ b/sources/lexer/check_if_var.c
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/15 23:40:24 by alexa             #+#    #+#             */
-/*   Updated: 2022/09/23 15:20:27 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 18:11:01 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static void	variable_check(t_token **token_node)
 	while ((*token_node)->str[i])
 	{
 		if ((*token_node)->str[i] == '$')
-		{	
+		{
 			if ((*token_node)->prev && (*token_node)->prev->type == HEREDOC)
 				break ;
 			(*token_node)->type = VAR;

--- a/sources/lexer/parse_user_input.c
+++ b/sources/lexer/parse_user_input.c
@@ -6,7 +6,7 @@
 /*   By: alexa <marvin@42.fr>                       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/10 00:01:18 by alexa             #+#    #+#             */
-/*   Updated: 2022/11/10 00:01:22 by alexa            ###   ########.fr       */
+/*   Updated: 2024/11/29 18:09:51 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,57 @@ static bool	input_is_space(char *input)
 	return (true);
 }
 
+/**
+ * Another stupid Norminette bypass.
+ * @brief	Updates the redirection type.
+ * @param	token_str	A string of current token.
+ * @param	redir_type	A pointer to the redirection type.
+ */
+static void	norminette_stuff_update_redir_type(const char *token_str,
+	enum e_redir_type *redir_type)
+{
+	if (ft_strncmp(token_str, "<<", sizeof("<<") - 1) == 0
+		|| ft_strncmp(token_str, "<", sizeof("<") - 1) == 0)
+		*redir_type = STDIN_REDIR;
+	else if (ft_strncmp(token_str, ">>", sizeof(">>") - 1) == 0
+		|| ft_strncmp(token_str, ">", sizeof(">") - 1) == 0)
+		*redir_type = STDOUT_REDIR;
+	else
+		*redir_type = NO_REDIR;
+}
+
+/**
+ * Easily the most stupid Norminette bypass.
+ * @brief	Checks if all redirections are followed by some file.
+ * @param	data	Pointer to the main data structure.
+ * @return	(SUCCESS) if all redirections are followed by some file.
+ * 			(FAILURE) otherwise.
+ */
+static int	norminette_stupid_bypass_check_redirs(t_data *data)
+{
+	enum e_redir_type	redir_type;
+	t_token				*current_token;
+
+	redir_type = NO_REDIR;
+	current_token = data->token;
+	while (current_token != NULL)
+	{
+		if ((ft_strncmp(current_token->str, "<<", sizeof("<<") - 1) == 0
+				|| ft_strncmp(current_token->str, "<", sizeof("<") - 1) == 0
+				|| ft_strncmp(current_token->str, ">>", sizeof(">>") - 1) == 0
+				|| ft_strncmp(current_token->str, ">", sizeof(">") - 1) == 0
+				|| ft_strncmp(current_token->str, "|", sizeof("|") - 1) == 0)
+			&& redir_type != NO_REDIR)
+		{
+			errmsg("expected the file before ", current_token->str, true);
+			return (FAILURE);
+		}
+		norminette_stuff_update_redir_type(current_token->str, &redir_type);
+		current_token = current_token->next;
+	}
+	return (SUCCESS);
+}
+
 /* parse_user_input:
 *	Tokenizes and parses user input into a structure for execution.
 *	Returns true if successful, false in case of error.
@@ -39,11 +90,9 @@ bool	parse_user_input(t_data *data)
 	else if (input_is_space(data->user_input))
 		return (true);
 	add_history(data->user_input);
-	if (tokenization(data, data->user_input) == FAILURE)
-		return (false);
-	if (data->token->type == END)
-		return (false);
-	if (check_if_var(&data->token) == FAILURE)
+	if (tokenization(data, data->user_input) == FAILURE
+		|| data->token->type == END || check_if_var(&data->token) == FAILURE
+		|| norminette_stupid_bypass_check_redirs(data) == FAILURE)
 		return (false);
 	var_expander(data, &data->token);
 	handle_quotes(data);

--- a/sources/lexer/parse_user_input.c
+++ b/sources/lexer/parse_user_input.c
@@ -6,7 +6,7 @@
 /*   By: alexa <marvin@42.fr>                       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/10 00:01:18 by alexa             #+#    #+#             */
-/*   Updated: 2024/11/29 18:09:51 by asagymba         ###   ########.fr       */
+/*   Updated: 2024/11/29 18:20:52 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,8 @@ static int	norminette_stupid_bypass_check_redirs(t_data *data)
 				|| ft_strncmp(current_token->str, "|", sizeof("|") - 1) == 0)
 			&& redir_type != NO_REDIR)
 		{
-			errmsg("expected the file before ", current_token->str, true);
+			errmsg("syntax error near unexpected token ", current_token->str,
+				true);
 			return (FAILURE);
 		}
 		norminette_stuff_update_redir_type(current_token->str, &redir_type);

--- a/sources/lexer/token_lst_utils.c
+++ b/sources/lexer/token_lst_utils.c
@@ -6,7 +6,7 @@
 /*   By: mcombeau <mcombeau@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/15 23:50:28 by alexa             #+#    #+#             */
-/*   Updated: 2022/11/07 14:49:40 by mcombeau         ###   ########.fr       */
+/*   Updated: 2024/11/29 18:10:56 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,12 +52,12 @@ void	lst_add_back_token(t_token **alst, t_token *new_node)
 void	lstdelone_token(t_token *lst, void (*del)(void *))
 {
 	if (del && lst && lst->str)
-	{	
+	{
 		(*del)(lst->str);
 		lst->str = NULL;
 	}
 	if (del && lst && lst->str_backup)
-	{	
+	{
 		(*del)(lst->str_backup);
 		lst->str_backup = NULL;
 	}

--- a/sources/parser/parse_heredoc_utils.c
+++ b/sources/parser/parse_heredoc_utils.c
@@ -6,7 +6,7 @@
 /*   By: alexa <marvin@42.fr>                       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/10 00:09:37 by alexa             #+#    #+#             */
-/*   Updated: 2022/11/10 00:09:40 by alexa            ###   ########.fr       */
+/*   Updated: 2024/11/29 18:11:49 by asagymba         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,8 +109,9 @@ static bool	evaluate_heredoc_line(t_data *data, char **line,
 }
 
 /* fill_heredoc:
-*	Copies user input into a temporary file. If user inputs an environment variable
-*	like $USER, expands the variable before writing to the heredoc.
+*	Copies user input into a temporary file. If user inputs an
+*	environment variable like $USER, expands the variable
+*	before writing to the heredoc.
 *	Returns true on success, false on failure.
 */
 bool	fill_heredoc(t_data *data, t_io_fds *io, int fd)


### PR DESCRIPTION
sizeof(char) is always 1 according to C standard, whilst sizeof(char *) may be different (usually 4 or 8 bytes).
<br>
Commit d64e38b fixes the incorrect size for `malloc()` in ft_split.c.
<br>
<br>
Commits 093aa67 and b59e393 fix Norminette and also #3.